### PR TITLE
Add feature to specify custom table names in Firestore Identity

### DIFF
--- a/src/Aguacongas.Identity.Firestore/FirestoreTableNamesConfig.cs
+++ b/src/Aguacongas.Identity.Firestore/FirestoreTableNamesConfig.cs
@@ -1,0 +1,24 @@
+namespace Aguacongas.Identity.Firestore
+{
+    public class FirestoreTableNamesConfig
+    {
+        private struct Defaults
+        {
+            internal const string UsersTableName = "users";
+            internal const string UserLoginsTableName = "user-logins";
+            internal const string UserClaimsTableName = "user-claims";
+            internal const string UserTokensTableName = "user-tokens";
+            internal const string RolesTableName = "roles";
+            internal const string RoleClaimsTableName = "role-claims";
+            internal const string UserRolesTableName = "users-roles";
+        }
+
+        public string UsersTableName { get; set; } = Defaults.UsersTableName;
+        public string UserLoginsTableName {get; set; } = Defaults.UserLoginsTableName;
+        public string UserClaimsTableName {get; set; } = Defaults.UserClaimsTableName;
+        public string UserTokensTableName {get; set; } = Defaults.UserTokensTableName;
+        public string RolesTableName {get; set; } = Defaults.RolesTableName;
+        public string RoleClaimsTableName {get; set; } = Defaults.RoleClaimsTableName;
+        public string UserRolesTableName {get; set; } = Defaults.UserRolesTableName;
+    }
+}

--- a/src/Aguacongas.Identity.Firestore/FirestoreTableNamesConfig.cs
+++ b/src/Aguacongas.Identity.Firestore/FirestoreTableNamesConfig.cs
@@ -1,16 +1,19 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Aguacongas.Identity.Firestore
 {
     public class FirestoreTableNamesConfig
     {
+        [SuppressMessage("ReSharper", "ConvertToConstant.Local")]
         private struct Defaults
         {
-            internal const string UsersTableName = "users";
-            internal const string UserLoginsTableName = "user-logins";
-            internal const string UserClaimsTableName = "user-claims";
-            internal const string UserTokensTableName = "user-tokens";
-            internal const string RolesTableName = "roles";
-            internal const string RoleClaimsTableName = "role-claims";
-            internal const string UserRolesTableName = "users-roles";
+            internal static readonly string UsersTableName = "users";
+            internal static readonly string UserLoginsTableName = "user-logins";
+            internal static readonly string UserClaimsTableName = "user-claims";
+            internal static readonly string UserTokensTableName = "user-tokens";
+            internal static readonly string RolesTableName = "roles";
+            internal static readonly string RoleClaimsTableName = "role-claims";
+            internal static readonly string UserRolesTableName = "users-roles";
         }
 
         public string UsersTableName { get; set; } = Defaults.UsersTableName;
@@ -20,5 +23,21 @@ namespace Aguacongas.Identity.Firestore
         public string RolesTableName {get; set; } = Defaults.RolesTableName;
         public string RoleClaimsTableName {get; set; } = Defaults.RoleClaimsTableName;
         public string UserRolesTableName {get; set; } = Defaults.UserRolesTableName;
+
+        /// <summary>
+        /// Adds suffix to every table names.
+        /// </summary>
+        /// <param name="suffix">suffix to add to every table name</param>
+        public FirestoreTableNamesConfig WithSuffix(string suffix)
+        {
+            UsersTableName += suffix;
+            UserLoginsTableName += suffix;
+            UserClaimsTableName += suffix;
+            UserTokensTableName += suffix;
+            RolesTableName += suffix;
+            RoleClaimsTableName += suffix;
+            UserRolesTableName += suffix;
+            return this;
+        }
     }
 }

--- a/src/Aguacongas.Identity.Firestore/RoleStore.cs
+++ b/src/Aguacongas.Identity.Firestore/RoleStore.cs
@@ -23,8 +23,9 @@ namespace Aguacongas.Identity.Firestore
         /// Constructs a new instance of <see cref="RoleStore{TRole}"/>.
         /// </summary>
         /// <param name="db">The <see cref="FirestoreDb"/>.</param>
+        /// <param name="tableNamesConfig"><see cref="FirestoreTableNamesConfig"/></param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
-        public RoleStore(FirestoreDb db, IdentityErrorDescriber describer = null) : base(db, describer) { }
+        public RoleStore(FirestoreDb db, FirestoreTableNamesConfig tableNamesConfig,  IdentityErrorDescriber describer = null) : base(db, tableNamesConfig, describer) { }
     }
 
     /// <summary>
@@ -45,9 +46,6 @@ namespace Aguacongas.Identity.Firestore
         where TUserRole : IdentityUserRole<string>, new()
         where TRoleClaim : IdentityRoleClaim<string>, new()
     {
-        private const string RolesTableName = "roles";
-        private const string RoleClaimsTableName = "role-claims";
-
         private readonly FirestoreDb _db;
         private readonly CollectionReference _roles;
         private readonly CollectionReference _roleClaims;
@@ -71,12 +69,14 @@ namespace Aguacongas.Identity.Firestore
         /// Constructs a new instance of <see cref="RoleStore{TRole, TUserRole, TRoleClaim}"/>.
         /// </summary>
         /// <param name="db">The <see cref="FirestoreDb"/>.</param>
+        /// <param name="tableNamesConfig"><see cref="FirestoreTableNamesConfig"/></param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
-        public RoleStore(FirestoreDb db, IdentityErrorDescriber describer = null)
+        public RoleStore(FirestoreDb db, FirestoreTableNamesConfig tableNamesConfig, IdentityErrorDescriber describer = null)
         {
             _db = db ?? throw new ArgumentNullException(nameof(db));
-            _roles = _db.Collection(RolesTableName);
-            _roleClaims = _db.Collection(RoleClaimsTableName);
+            tableNamesConfig = tableNamesConfig ?? throw new ArgumentNullException(nameof(tableNamesConfig));
+            _roles = _db.Collection(tableNamesConfig.RolesTableName);
+            _roleClaims = _db.Collection(tableNamesConfig.RoleClaimsTableName);
             ErrorDescriber = describer ?? new IdentityErrorDescriber();
         }
 

--- a/src/Aguacongas.Identity.Firestore/UserOnlyStore.cs
+++ b/src/Aguacongas.Identity.Firestore/UserOnlyStore.cs
@@ -21,8 +21,9 @@ namespace Aguacongas.Identity.Firestore
         /// Constructs a new instance of <see cref="UserStore{TUser, TRole, TKey}"/>.
         /// </summary>
         /// <param name="db">The <see cref="FirestoreDb"/>.</param>
+        /// <param name="tableNamesConfig"><see cref="FirestoreTableNamesConfig"/></param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
-        public UserOnlyStore(FirestoreDb db, IdentityErrorDescriber describer = null) : base(db, describer) { }
+        public UserOnlyStore(FirestoreDb db, FirestoreTableNamesConfig tableNamesConfig, IdentityErrorDescriber describer = null) : base(db, tableNamesConfig, describer) { }
     }
 
     /// <summary>
@@ -36,8 +37,9 @@ namespace Aguacongas.Identity.Firestore
         /// Constructs a new instance of <see cref="UserStore{TUser, TRole, TKey}"/>.
         /// </summary>
         /// <param name="db">The <see cref="FirestoreDb"/>.</param>
+        /// <param name="tableNamesConfig"><see cref="FirestoreTableNamesConfig"/></param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
-        public UserOnlyStore(FirestoreDb db, IdentityErrorDescriber describer = null) : base(db, describer) { }
+        public UserOnlyStore(FirestoreDb db, FirestoreTableNamesConfig tableNamesConfig, IdentityErrorDescriber describer = null) : base(db, tableNamesConfig, describer) { }
     }
 
 
@@ -67,10 +69,6 @@ namespace Aguacongas.Identity.Firestore
         where TUserLogin : IdentityUserLogin<string>, new()
         where TUserToken : IdentityUserToken<string>, new()
     {
-        private const string UsersTableName = "users";
-        private const string UserLoginsTableName = "user-logins";
-        private const string UserClaimsTableName = "user-claims";
-        private const string UserTokensTableName = "user-tokens";
 
         private readonly FirestoreDb _db;
         private readonly CollectionReference _users;
@@ -94,14 +92,16 @@ namespace Aguacongas.Identity.Firestore
         /// Creates a new instance of the store.
         /// </summary>
         /// <param name="db">The <see cref="FirestoreDb"/>.</param>
+        /// <param name="tableNamesConfig"><see cref="FirestoreTableNamesConfig"/></param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/> used to describe store errors.</param>
-        public UserOnlyStore(FirestoreDb db, IdentityErrorDescriber describer = null) : base(describer ?? new IdentityErrorDescriber())
+        public UserOnlyStore(FirestoreDb db, FirestoreTableNamesConfig tableNamesConfig, IdentityErrorDescriber describer = null) : base(describer ?? new IdentityErrorDescriber())
         {
             _db = db ?? throw new ArgumentNullException(nameof(db));
-            _users = db.Collection(UsersTableName);
-            _usersLogins = db.Collection(UserLoginsTableName);
-            _usersClaims = db.Collection(UserClaimsTableName);
-            _usersTokens = db.Collection(UserTokensTableName);
+            tableNamesConfig = tableNamesConfig ?? throw new ArgumentNullException(nameof(tableNamesConfig));
+            _users = db.Collection(tableNamesConfig.UsersTableName);
+            _usersLogins = db.Collection(tableNamesConfig.UserLoginsTableName);
+            _usersClaims = db.Collection(tableNamesConfig.UserClaimsTableName);
+            _usersTokens = db.Collection(tableNamesConfig.UserTokensTableName);
         }
 
         /// <summary>

--- a/src/Aguacongas.Identity.Firestore/UserStore.cs
+++ b/src/Aguacongas.Identity.Firestore/UserStore.cs
@@ -23,8 +23,9 @@ namespace Aguacongas.Identity.Firestore
         /// Constructs a new instance of <see cref="UserStore"/>.
         /// </summary>
         /// <param name="db">The <see cref="FirestoreDb"/>.</param>
+        /// <param name="tableNamesConfig"><see cref="FirestoreTableNamesConfig"/></param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
-        public UserStore(FirestoreDb db, UserOnlyStore<IdentityUser<string>> userOnlyStore, IdentityErrorDescriber describer = null) : base(db, userOnlyStore, describer) { }
+        public UserStore(FirestoreDb db, UserOnlyStore<IdentityUser<string>> userOnlyStore, FirestoreTableNamesConfig tableNamesConfig, IdentityErrorDescriber describer = null) : base(db, userOnlyStore, tableNamesConfig, describer) { }
     }
 
     /// <summary>
@@ -38,8 +39,9 @@ namespace Aguacongas.Identity.Firestore
         /// Constructs a new instance of <see cref="UserStore{TUser}"/>.
         /// </summary>
         /// <param name="db">The <see cref="FirestoreDb"/>.</param>
+        /// <param name="tableNamesConfig"><see cref="FirestoreTableNamesConfig"/></param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
-        public UserStore(FirestoreDb db, UserOnlyStore<TUser> userOnlyStore, IdentityErrorDescriber describer = null) : base(db, userOnlyStore, describer) { }
+        public UserStore(FirestoreDb db, UserOnlyStore<TUser> userOnlyStore, FirestoreTableNamesConfig tableNamesConfig, IdentityErrorDescriber describer = null) : base(db, userOnlyStore, tableNamesConfig, describer) { }
     }
 
     /// <summary>
@@ -55,8 +57,9 @@ namespace Aguacongas.Identity.Firestore
         /// Constructs a new instance of <see cref="UserStore{TUser, TRole, TContext, string}"/>.
         /// </summary>
         /// <param name="db">The <see cref="FirestoreDb"/>.</param>
+        /// <param name="tableNamesConfig"><param name="tableNamesConfig"><see cref="FirestoreTableNamesConfig"/></param></param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
-        public UserStore(FirestoreDb db, UserOnlyStore<TUser> userOnlyStore, IdentityErrorDescriber describer = null) : base(db, userOnlyStore, describer) { }
+        public UserStore(FirestoreDb db, UserOnlyStore<TUser> userOnlyStore, FirestoreTableNamesConfig tableNamesConfig, IdentityErrorDescriber describer = null) : base(db, userOnlyStore, tableNamesConfig, describer) { }
     }
 
 
@@ -81,10 +84,6 @@ namespace Aguacongas.Identity.Firestore
         where TUserToken : IdentityUserToken<string>, new()
         where TRoleClaim : IdentityRoleClaim<string>, new()
     {
-        private const string UserRolesTableName = "users-roles";
-        private const string RolesTableName = "roles";
-
-
         private readonly CollectionReference _userRoles;
         private readonly CollectionReference _roles;
         private readonly UserOnlyStore<TUser, TUserClaim, TUserLogin, TUserToken> _userOnlyStore;
@@ -98,13 +97,15 @@ namespace Aguacongas.Identity.Firestore
         /// Creates a new instance of the store.
         /// </summary>
         /// <param name="db">The <see cref="FirestoreDb"/>.</param>
+        /// <param name="tableNamesConfig"><see cref="FirestoreTableNamesConfig"/></param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/> used to describe store errors.</param>
-        public UserStore(FirestoreDb db, UserOnlyStore<TUser, TUserClaim, TUserLogin, TUserToken> userOnlyStore, IdentityErrorDescriber describer = null) : base(describer ?? new IdentityErrorDescriber())
+        public UserStore(FirestoreDb db, UserOnlyStore<TUser, TUserClaim, TUserLogin, TUserToken> userOnlyStore, FirestoreTableNamesConfig tableNamesConfig, IdentityErrorDescriber describer = null) : base(describer ?? new IdentityErrorDescriber())
         {
             db = db ?? throw new ArgumentNullException(nameof(db));
+            tableNamesConfig = tableNamesConfig ?? throw new ArgumentNullException(nameof(tableNamesConfig));
             _userOnlyStore = userOnlyStore ?? throw new ArgumentNullException(nameof(userOnlyStore));
-            _userRoles = db.Collection(UserRolesTableName);
-            _roles = db.Collection(RolesTableName);
+            _userRoles = db.Collection(tableNamesConfig.UserRolesTableName);
+            _roles = db.Collection(tableNamesConfig.RolesTableName);
         }
 
         /// <summary>

--- a/test/Aguacongas.Identity.Firestore.IntegrationTest/FirestoreTestFixture.cs
+++ b/test/Aguacongas.Identity.Firestore.IntegrationTest/FirestoreTestFixture.cs
@@ -31,14 +31,19 @@ namespace Aguacongas.Identity.Firestore.IntegrationTest
             {
                 return CreateFirestoreDb(provider);
             });
+            
+            var tableNames = new FirestoreTableNamesConfig().WithSuffix("-tests");
+            services.AddSingleton(tableNames);
+            
             var p = services.BuildServiceProvider();
             var db = p.GetRequiredService<FirestoreDb>();
-            Clean(db.Collection("users"));
-            Clean(db.Collection("user-logins"));
-            Clean(db.Collection("user-claims"));
-            Clean(db.Collection("user-tokens"));
-            Clean(db.Collection("roles"));
-            Clean(db.Collection("role-claims"));
+            
+            Clean(db.Collection(tableNames.UsersTableName));
+            Clean(db.Collection(tableNames.UserLoginsTableName));
+            Clean(db.Collection(tableNames.UserClaimsTableName));
+            Clean(db.Collection(tableNames.UserTokensTableName));
+            Clean(db.Collection(tableNames.RolesTableName));
+            Clean(db.Collection(tableNames.RoleClaimsTableName));
         }
 
         private static void Clean(CollectionReference collection)

--- a/test/Aguacongas.Identity.Firestore.IntegrationTest/RoleStoreStub.cs
+++ b/test/Aguacongas.Identity.Firestore.IntegrationTest/RoleStoreStub.cs
@@ -9,7 +9,7 @@ namespace Aguacongas.Identity.Firestore.IntegrationTest
     {
         private readonly string _testDb;
 
-        public RoleStoreStub(string testDb, FirestoreDb db, IdentityErrorDescriber describer = null) : base(db, describer)
+        public RoleStoreStub(string testDb, FirestoreDb db, FirestoreTableNamesConfig tableNamesConfig, IdentityErrorDescriber describer = null) : base(db, tableNamesConfig, describer)
         {
             _testDb = testDb;
         }

--- a/test/Aguacongas.Identity.Firestore.IntegrationTest/UserOnlyStoreStub.cs
+++ b/test/Aguacongas.Identity.Firestore.IntegrationTest/UserOnlyStoreStub.cs
@@ -9,7 +9,7 @@ namespace Aguacongas.Identity.Firestore.IntegrationTest
     {
         private readonly string _testDb;
 
-        public UserOnlyStoreStub(string testDb, FirestoreDb db, IdentityErrorDescriber describer = null) : base(db, describer)
+        public UserOnlyStoreStub(string testDb, FirestoreDb db, FirestoreTableNamesConfig tableNamesConfig, IdentityErrorDescriber describer = null) : base(db, tableNamesConfig, describer)
         {
             _testDb = testDb;
         }

--- a/test/Aguacongas.Identity.Firestore.IntegrationTest/UserStoreStub.cs
+++ b/test/Aguacongas.Identity.Firestore.IntegrationTest/UserStoreStub.cs
@@ -9,7 +9,7 @@ namespace Aguacongas.Identity.Firestore.IntegrationTest
     {
         private readonly string _testDb;
 
-        public UserStoreStub(string testDb, FirestoreDb db, UserOnlyStore<TestUser> userOnlyStore, IdentityErrorDescriber describer = null) : base(db, userOnlyStore, describer)
+        public UserStoreStub(string testDb, FirestoreDb db, UserOnlyStore<TestUser> userOnlyStore, FirestoreTableNamesConfig tableNamesConfig, IdentityErrorDescriber describer = null) : base(db, userOnlyStore, tableNamesConfig, describer)
         {
             _testDb = testDb;
         }

--- a/test/Aguacongas.Identity.Firestore.IntegrationTest/UserStoreTest.cs
+++ b/test/Aguacongas.Identity.Firestore.IntegrationTest/UserStoreTest.cs
@@ -1,5 +1,6 @@
 // Project: aguacongas/Identity.Firebase
 // Copyright (c) 2020 @Olivier Lefebvre
+
 using Aguacongas.Firebase.TokenManager;
 using Google.Cloud.Firestore;
 using Microsoft.AspNetCore.Identity;
@@ -22,28 +23,29 @@ namespace Aguacongas.Identity.Firestore.IntegrationTest
             _fixture = fixture;
         }
 
+        protected override void SetupIdentityServices(IServiceCollection services, object context)
+        {
+            services.AddSingleton(new FirestoreTableNamesConfig().WithSuffix("-tests"));
+            base.SetupIdentityServices(services, context);
+        }
+
         protected override void AddUserStore(IServiceCollection services, object context = null)
         {
             services.Configure<OAuthServiceAccountKey>(options =>
             {
                 _fixture.Configuration.GetSection("FirestoreAuthTokenOptions").Bind(options);
-            }).AddScoped(provider =>
-            {
-                return FirestoreTestFixture.CreateFirestoreDb(provider);
-            });
-            
-            services.TryAddSingleton(new FirestoreTableNamesConfig());
-            
+            }).AddScoped(provider => { return FirestoreTestFixture.CreateFirestoreDb(provider); });
+
             var userType = typeof(TestUser);
-            services.TryAddSingleton(typeof(UserOnlyStore<>).MakeGenericType(userType), 
-                provider => new UserOnlyStoreStub(_fixture.TestDb, 
-                    provider.GetRequiredService<FirestoreDb>(), 
+            services.TryAddSingleton(typeof(UserOnlyStore<>).MakeGenericType(userType),
+                provider => new UserOnlyStoreStub(_fixture.TestDb,
+                    provider.GetRequiredService<FirestoreDb>(),
                     provider.GetRequiredService<FirestoreTableNamesConfig>(),
                     provider.GetService<IdentityErrorDescriber>()));
-            services.TryAddSingleton(typeof(IUserStore<>).MakeGenericType(userType), 
-                provider => new UserStoreStub(_fixture.TestDb, 
+            services.TryAddSingleton(typeof(IUserStore<>).MakeGenericType(userType),
+                provider => new UserStoreStub(_fixture.TestDb,
                     provider.GetRequiredService<FirestoreDb>(),
-                    provider.GetRequiredService<UserOnlyStore<TestUser>>(), 
+                    provider.GetRequiredService<UserOnlyStore<TestUser>>(),
                     provider.GetRequiredService<FirestoreTableNamesConfig>(),
                     provider.GetService<IdentityErrorDescriber>()));
         }
@@ -51,7 +53,6 @@ namespace Aguacongas.Identity.Firestore.IntegrationTest
         protected override void AddRoleStore(IServiceCollection services, object context = null)
         {
             var roleType = typeof(TestRole);
-            services.TryAddSingleton(new FirestoreTableNamesConfig());
             services.TryAddSingleton(typeof(IRoleStore<>).MakeGenericType(roleType),
                 provider => new RoleStoreStub(_fixture.TestDb,
                     provider.GetRequiredService<FirestoreDb>(),
@@ -78,7 +79,9 @@ namespace Aguacongas.Identity.Firestore.IntegrationTest
 
         protected override TestRole CreateTestRole(string roleNamePrefix = "", bool useRoleNamePrefixAsRoleName = false)
         {
-            var roleName = useRoleNamePrefixAsRoleName ? roleNamePrefix : string.Format("{0}{1}", roleNamePrefix, Guid.NewGuid());
+            var roleName = useRoleNamePrefixAsRoleName
+                ? roleNamePrefix
+                : string.Format("{0}{1}", roleNamePrefix, Guid.NewGuid());
             return new TestRole(roleName);
         }
 
@@ -87,12 +90,16 @@ namespace Aguacongas.Identity.Firestore.IntegrationTest
             user.PasswordHash = hashedPassword;
         }
 
-        protected override Expression<Func<TestUser, bool>> UserNameEqualsPredicate(string userName) => u => u.UserName == userName;
+        protected override Expression<Func<TestUser, bool>> UserNameEqualsPredicate(string userName) =>
+            u => u.UserName == userName;
 
-        protected override Expression<Func<TestRole, bool>> RoleNameEqualsPredicate(string roleName) => r => r.Name == roleName;
+        protected override Expression<Func<TestRole, bool>> RoleNameEqualsPredicate(string roleName) =>
+            r => r.Name == roleName;
 
-        protected override Expression<Func<TestRole, bool>> RoleNameStartsWithPredicate(string roleName) => r => r.Name != null && r.Name.StartsWith(roleName);
+        protected override Expression<Func<TestRole, bool>> RoleNameStartsWithPredicate(string roleName) =>
+            r => r.Name != null && r.Name.StartsWith(roleName);
 
-        protected override Expression<Func<TestUser, bool>> UserNameStartsWithPredicate(string userName) => u => u.UserName != null &&  u.UserName.StartsWith(userName);
+        protected override Expression<Func<TestUser, bool>> UserNameStartsWithPredicate(string userName) =>
+            u => u.UserName != null && u.UserName.StartsWith(userName);
     }
 }

--- a/test/Aguacongas.Identity.Firestore.IntegrationTest/UserStoreTest.cs
+++ b/test/Aguacongas.Identity.Firestore.IntegrationTest/UserStoreTest.cs
@@ -31,16 +31,31 @@ namespace Aguacongas.Identity.Firestore.IntegrationTest
             {
                 return FirestoreTestFixture.CreateFirestoreDb(provider);
             });
-
+            
+            services.TryAddSingleton(new FirestoreTableNamesConfig());
+            
             var userType = typeof(TestUser);
-            services.TryAddSingleton(typeof(UserOnlyStore<>).MakeGenericType(userType), provider => new UserOnlyStoreStub(_fixture.TestDb, provider.GetRequiredService<FirestoreDb>(), provider.GetService<IdentityErrorDescriber>()));
-            services.TryAddSingleton(typeof(IUserStore<>).MakeGenericType(userType), provider => new UserStoreStub(_fixture.TestDb, provider.GetRequiredService<FirestoreDb>(), provider.GetRequiredService<UserOnlyStore<TestUser>>(), provider.GetService<IdentityErrorDescriber>()));
+            services.TryAddSingleton(typeof(UserOnlyStore<>).MakeGenericType(userType), 
+                provider => new UserOnlyStoreStub(_fixture.TestDb, 
+                    provider.GetRequiredService<FirestoreDb>(), 
+                    provider.GetRequiredService<FirestoreTableNamesConfig>(),
+                    provider.GetService<IdentityErrorDescriber>()));
+            services.TryAddSingleton(typeof(IUserStore<>).MakeGenericType(userType), 
+                provider => new UserStoreStub(_fixture.TestDb, 
+                    provider.GetRequiredService<FirestoreDb>(),
+                    provider.GetRequiredService<UserOnlyStore<TestUser>>(), 
+                    provider.GetRequiredService<FirestoreTableNamesConfig>(),
+                    provider.GetService<IdentityErrorDescriber>()));
         }
 
         protected override void AddRoleStore(IServiceCollection services, object context = null)
         {
             var roleType = typeof(TestRole);
-            services.TryAddSingleton(typeof(IRoleStore<>).MakeGenericType(roleType), provider => new RoleStoreStub(_fixture.TestDb, provider.GetRequiredService<FirestoreDb>()));
+            services.TryAddSingleton(new FirestoreTableNamesConfig());
+            services.TryAddSingleton(typeof(IRoleStore<>).MakeGenericType(roleType),
+                provider => new RoleStoreStub(_fixture.TestDb,
+                    provider.GetRequiredService<FirestoreDb>(),
+                    provider.GetRequiredService<FirestoreTableNamesConfig>()));
         }
 
         protected override object CreateTestContext()

--- a/test/Aguacongas.Identity.Firestore.Test/UserStoreTest.cs
+++ b/test/Aguacongas.Identity.Firestore.Test/UserStoreTest.cs
@@ -58,9 +58,10 @@ namespace Aguacongas.Identity.Firestore.Test
             Assert.Throws<ArgumentNullException>("db", () => new UserStore(null, null, null));
             var db = CreateDb();
 
-            Assert.Throws<ArgumentNullException>("userOnlyStore", () => new UserStore(db, null, null));
+            Assert.Throws<ArgumentNullException>("tableNamesConfig", () => new UserStore(db, null, null));
 
             var tableNamesConfig = new FirestoreTableNamesConfig();
+            Assert.Throws<ArgumentNullException>("userOnlyStore", () => new UserStore(db, null, tableNamesConfig));
             
             var userOnlyStore = new UserOnlyStore(db, tableNamesConfig);
             var store = new UserStore(db, userOnlyStore, tableNamesConfig);

--- a/test/Aguacongas.Identity.Firestore.Test/UserStoreTest.cs
+++ b/test/Aguacongas.Identity.Firestore.Test/UserStoreTest.cs
@@ -20,8 +20,9 @@ namespace Aguacongas.Identity.Firestore.Test
         {
             var db = CreateDb();
 
-            var userOnlyStore = new UserOnlyStore(db);
-            var store = new UserStore(db, userOnlyStore);
+            var tableNamesConfig = new FirestoreTableNamesConfig();
+            var userOnlyStore = new UserOnlyStore(db, tableNamesConfig);
+            var store = new UserStore(db, userOnlyStore, tableNamesConfig);
             store.Dispose();
             await Assert.ThrowsAsync<ObjectDisposedException>(async () => await store.AddClaimsAsync(null, null));
             await Assert.ThrowsAsync<ObjectDisposedException>(async () => await store.AddLoginAsync(null, null));
@@ -54,13 +55,15 @@ namespace Aguacongas.Identity.Firestore.Test
         [Fact]
         public async Task UserStorePublicNullCheckTest()
         {
-            Assert.Throws<ArgumentNullException>("db", () => new UserStore(null, null));
+            Assert.Throws<ArgumentNullException>("db", () => new UserStore(null, null, null));
             var db = CreateDb();
 
-            Assert.Throws<ArgumentNullException>("userOnlyStore", () => new UserStore(db, null));
+            Assert.Throws<ArgumentNullException>("userOnlyStore", () => new UserStore(db, null, null));
 
-            var userOnlyStore = new UserOnlyStore(db);
-            var store = new UserStore(db, userOnlyStore);
+            var tableNamesConfig = new FirestoreTableNamesConfig();
+            
+            var userOnlyStore = new UserOnlyStore(db, tableNamesConfig);
+            var store = new UserStore(db, userOnlyStore, tableNamesConfig);
             await Assert.ThrowsAsync<ArgumentNullException>("user", async () => await store.GetUserIdAsync(null));
             await Assert.ThrowsAsync<ArgumentNullException>("user", async () => await store.GetUserNameAsync(null));
             await Assert.ThrowsAsync<ArgumentNullException>("user", async () => await store.SetUserNameAsync(null, null));


### PR DESCRIPTION
I would like to add this feature to support multiple apps running within the same GCP project and use Firestore Identity in each of them.

I was not able to run the tests locally, due to keys being encrypted in the repo.

I'm open for discussions about the solution too.